### PR TITLE
chore: Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Maintain dependencies for client
+  - package-ecosystem: "npm"
+    directory: "/packages/client/"
+    schedule:
+      interval: "daily"
+      time: "12:00"
+      timezone: "America/New_York"
+    labels:
+      - "a: dependencies"
+      - "npm: client"
+    commit-message:
+      prefix: "npm(client)"
+  # Maintain dependencies for server
+  - package-ecosystem: "npm"
+    directory: "/packages/server/"
+    schedule:
+      interval: "daily"
+      time: "12:00"
+      timezone: "America/New_York"
+    labels:
+      - "a: dependencies"
+      - "npm: server"
+    commit-message:
+      prefix: "npm(server)"


### PR DESCRIPTION
Configure dependabot to keep the client and server packages up to date, along with to use the relevant directories.